### PR TITLE
Use proper URL for git-it

### DIFF
--- a/content/work.md
+++ b/content/work.md
@@ -15,7 +15,7 @@
 
 During the day I work at GitHub on [Electron](http://electron.atom.io). Outside of that I'm still building. Below are a few personal projects—much more can be found on [my GitHub](https://github.com/jlord).
 
-[**Git-it**](https://jlord.github.io/git-it-electron) An interactive desktop app for learning Git and GitHub.
+[**Git-it**](https://github.com/jlord/git-it-electron) An interactive desktop app for learning Git and GitHub.
 
 [**Sheetsee.js**](https://jlord.github.io/sheetsee.js) A library for visualizing data from Google Spreadsheets.
 


### PR DESCRIPTION
The url in question <a href='https://jlord.github.io/git-it-electron' target='_blank'>`https://jlord.github.io/git-it-electron`</a> results in a 404 on the live site

It might need to be updated in a few other spots?

Alternatively, you could redirect.
